### PR TITLE
Fix: add scheduled task to fix hardcoded files

### DIFF
--- a/classes/task/replace_pluginfile_urls.php
+++ b/classes/task/replace_pluginfile_urls.php
@@ -26,19 +26,18 @@ namespace local_rollover_wizard\task;
 /**
  * Executes a rollover process.
  *
- * This class is responsible for performing a rollover operation.
+ * This class is responsible for performing a calculate course size
  *
  * @package core\task
  */
-class execute_rollover extends \core\task\scheduled_task {
+class replace_pluginfile_urls extends \core\task\scheduled_task {
     /**
      * Gets the name of the task.
      *
      * @return string The name of the task.
      */
     public function get_name() {
-        // Shown on admin screens
-        return 'Rollover Wizard - Execute Rollover';
+        return get_string('replace_pluginfile_urls', 'local_rollover_wizard');
     }
 
     /**
@@ -47,22 +46,19 @@ class execute_rollover extends \core\task\scheduled_task {
      * @return bool True if the rollover was successful, false otherwise.
      */
     public function execute() {
-
         global $CFG;
-
         require_once($CFG->dirroot . '/local/rollover_wizard/lib.php');
-        local_rollover_wizard_executerollover();
-
+        local_rollover_wizard_replace_urls_section();
         return true;
     }
 
-     /**
-      * Checks if the task can run.
-      *
-      * This method always returns true, indicating that the task can run anytime.
-      *
-      * @return bool True if the task can run, false otherwise.
-      */
+    /**
+     * Checks if the task can run.
+     *
+     * This method always returns true, indicating that the task can run anytime.
+     *
+     * @return bool True if the task can run, false otherwise.
+     */
     public function can_run(): bool {
         return true;
     }

--- a/db/install.xml
+++ b/db/install.xml
@@ -39,5 +39,24 @@
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
       </KEYS>
     </TABLE>
+
+    <TABLE NAME="local_rollover_wizard_sectionlog" COMMENT="Temporary log for tracking course section summary changes by scheduled task.">
+      <FIELDS>
+          <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+
+          <FIELD NAME="sectionid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="ID from course_sections"/>
+          
+          <FIELD NAME="courseid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Course ID from the section"/>
+          
+          <FIELD NAME="oldsummary" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Summary before being updated"/>
+          
+          <FIELD NAME="newsummary" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Summary after being updated"/>
+          
+          <FIELD NAME="timecreated" TYPE="int" LENGTH="20" NOTNULL="true" SEQUENCE="false" COMMENT="Timestamp when the change was logged"/>
+      </FIELDS>
+      <KEYS>
+          <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+      </KEYS>
+    </TABLE>
   </TABLES>
 </XMLDB>

--- a/db/tasks.php
+++ b/db/tasks.php
@@ -44,4 +44,14 @@ $tasks = [
         'month' => '*',
         'disabled' => 0,
     ],
+    [
+        'classname' => 'local_rollover_wizard\task\replace_pluginfile_urls',
+        'blocking' => 0,
+        'minute' => '0',
+        'hour' => '2',
+        'day' => '*',
+        'month' => '*',
+        'dayofweek' => '*',
+        'disabled' => 1,
+    ],
 ];

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -167,5 +167,27 @@ function xmldb_local_rollover_wizard_upgrade($oldversion) {
         // Rollover_wizard savepoint reached.
         upgrade_plugin_savepoint(true, 2024061401, 'local', 'rollover_wizard');
     }
+
+    if ($oldversion < 2025072900) {
+
+        // Define table rollover_wizard_sectionlog to be created.
+        $table = new xmldb_table('local_rollover_wizard_sectionlog');
+
+        // Adding fields.
+        $table->add_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE, null);
+        $table->add_field('sectionid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('courseid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('oldsummary', XMLDB_TYPE_TEXT, null, null, null, null, null);
+        $table->add_field('newsummary', XMLDB_TYPE_TEXT, null, null, null, null, null);
+        $table->add_field('timecreated', XMLDB_TYPE_INTEGER, '20', null, XMLDB_NOTNULL, null, null);
+
+        // Adding keys.
+        $table->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
+        // Conditionally create the table.
+        if (!$dbman->table_exists($table)) {
+            $dbman->create_table($table);
+        }
+        upgrade_plugin_savepoint(true, 2025072900, 'local', 'rollover_wizard');
+    }
     return true;
 }

--- a/lang/en/local_rollover_wizard.php
+++ b/lang/en/local_rollover_wizard.php
@@ -25,27 +25,28 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$string['pluginname'] = 'Content Rollover Wizard';
-$string['importcourse'] = 'Import Content';
-$string['rollover_wizard:edit'] = 'Allow access to Content Rollover Wizard';
+$string["config:enable_link"] = "Update Internal Links";
+$string["config:enable_link:desc"] = "Check this box to update internal and embedded links so that they point to the target course. If left unchecked, the links will remain pointing to the source course";
 $string['content_option1'] = 'Import a module page template';
 $string['content_option2'] = 'Import content from another module page';
-
-$string['setting_page:category'] = 'Rollover Wizard';
-
+$string['cron_schedulling_description'] = 'Tick this checkbox to enable cron schedulling to make rollover task above threshold setting below run through scheduled task. If this disabled, all rollover task will instantly executed';
 $string['emailtemplate'] = '
 Dear {FULLNAME},
 <br><br>
 A course content rollover has been completed. View the results here: {REPORT-LINK}';
+$string['importcourse'] = 'Import Content';
+$string['pluginname'] = 'Content Rollover Wizard';
+$string['replace_pluginfile_urls'] = 'Rollover Wizard - Execute Replace Pluginfile URLs';
+$string['rollover_wizard:edit'] = 'Allow access to Content Rollover Wizard';
+
+$string['setting_page:category'] = 'Rollover Wizard';
+
+$string["setting_page:limit_question"] = "Question threshold for scheduled run";
+$string["setting_page:limit_question:desc"] = "The question limit for the scheduled run must be set to ensure optimal performance";
 $string['wizard_support_company'] = 'LXI';
 $string['wizard_support_link'] = 'https://google.com';
 $string['wizard_support_text'] = 'The content import did not complete due to : <br>{NOTE}<br><p>Please contact {LINK} for support</p>';
 
-$string['cron_schedulling_description'] = 'Tick this checkbox to enable cron schedulling to make rollover task above threshold setting below run through scheduled task. If this disabled, all rollover task will instantly executed';
-
-$string["config:enable_link"] = "Update Internal Links";
-$string["config:enable_link:desc"] = "Check this box to update internal and embedded links so that they point to the target course. If left unchecked, the links will remain pointing to the source course";
 
 
-$string["setting_page:limit_question"]="Question threshold for scheduled run";
-$string["setting_page:limit_question:desc"]="The question limit for the scheduled run must be set to ensure optimal performance";
+

--- a/lib.php
+++ b/lib.php
@@ -540,8 +540,8 @@ function local_rollover_wizard_check_question_bank($coursetarget, $coursecontext
         $contextidcategory = array_unique($contextidcategory);
         if (!empty($contextidcategory)) {
             $sql = "
-            SELECT qbe.id AS question_id, 
-            qbe.questioncategoryid, 
+            SELECT qbe.id AS question_id,
+            qbe.questioncategoryid,
             COALESCE(COUNT(qr.questionbankentryid), 0) AS usage_count
             FROM {question_bank_entries} qbe
             LEFT JOIN {question_references} qr ON qr.questionbankentryid = qbe.id
@@ -629,7 +629,6 @@ function local_rollover_wizard_course_create_sections_if_missing(
 function local_rollover_wizard_rewrite_summary($sourcesection, $targetsection) {
     global $DB;
     $summary = $sourcesection->summary;
-
     $sourcecontext = \context_course::instance($sourcesection->course);
     $targetcontext = \context_course::instance($targetsection->course);
     $doc = new DOMDocument;
@@ -643,7 +642,6 @@ function local_rollover_wizard_rewrite_summary($sourcesection, $targetsection) {
             $nameonly = str_replace('@@PLUGINFILE@@/', '', $src->nodeValue);
             $nameonly = explode('?', $nameonly)[0];
             $nameonly = urldecode($nameonly);
-
             $sql = "SELECT itemid
                     FROM {files}
                     WHERE component='course'
@@ -652,9 +650,7 @@ function local_rollover_wizard_rewrite_summary($sourcesection, $targetsection) {
                         AND contextid=:contextid LIMIT 1";
             $fileitemid = $DB->get_field_sql($sql, ['contextid' => $targetcontext->id, 'filename' => $nameonly]);
             if (empty($fileitemid)) {
-
                 $fs = get_file_storage();
-
                 // Get Source file.
                 $file = $fs->get_file($sourcecontext->id, 'course', 'section', $sourcesection->id, '/', $nameonly);
                 if (!$file) {
@@ -674,25 +670,25 @@ function local_rollover_wizard_rewrite_summary($sourcesection, $targetsection) {
 
                 $fileitemid = $DB->get_field_sql($sql, ['contextid' => $targetcontext->id, 'filename' => $nameonly]);
             }
-
             if (!empty($fileitemid)) {
-                $imgpath = file_rewrite_pluginfile_urls(
-                    $src->nodeValue,
-                    'pluginfile.php',
-                    $targetcontext->id,
-                    'course',
-                    'section',
-                    $fileitemid
-                );
-                $summary = str_replace($src->nodeValue, $imgpath, $summary);
+                $summary = str_replace($src->nodeValue, '@@PLUGINFILE@@/' . $nameonly, $summary);
             }
         }
     }
 
     return $summary;
 }
-
-
+/**
+ * Rewrite file URLs in the intro/summary field from source module to target module
+ * using the @@PLUGINFILE@@ format.
+ *
+ * This is typically used during course copy/rollover to ensure that
+ * file references are correctly adjusted in the new context.
+ *
+ * @param stdClass $sourcemodule The source module object (original course).
+ * @param stdClass $targetmodule The target module object (copied course).
+ * @return void
+ */
 function local_rollover_wizard_rewrite_format_intro($sourcemodule, $targetmodule) {
     global $DB;
 
@@ -712,7 +708,6 @@ function local_rollover_wizard_rewrite_format_intro($sourcemodule, $targetmodule
             $nameonly = str_replace('@@PLUGINFILE@@/', '', $src->nodeValue);
             $nameonly = explode('?', $nameonly)[0];
             $nameonly = urldecode($nameonly);
-
             $sql = "SELECT itemid
                     FROM {files}
                     WHERE component='mod{$targetmodule->modname}'
@@ -720,7 +715,6 @@ function local_rollover_wizard_rewrite_format_intro($sourcemodule, $targetmodule
                         AND " . $DB->sql_compare_text('filename') . "=" . $DB->sql_compare_text(':filename') . "
                         AND contextid=:contextid LIMIT 1";
             $fileitemid = $DB->get_field_sql($sql, ['contextid' => $targetcontext->id, 'filename' => $nameonly]);
-
             if (empty($fileitemid)) {
                 $fs = get_file_storage();
                 $file = $fs->get_file(
@@ -744,24 +738,13 @@ function local_rollover_wizard_rewrite_format_intro($sourcemodule, $targetmodule
                     'timemodified' => time(),
                 ];
                 $fs->create_file_from_storedfile($newfilerecord, $file);
-
                 $fileitemid = $DB->get_field_sql($sql, ['contextid' => $targetcontext->id, 'filename' => $nameonly]);
             }
-
             if (!empty($fileitemid)) {
-                $path = file_rewrite_pluginfile_urls(
-                    $src->nodeValue,
-                    'pluginfile.php',
-                    $targetcontext->id,
-                    'mod_' . $targetmodule->modname,
-                    'intro',
-                    $fileitemid
-                );
                 $summary = str_replace($src->nodeValue, '@@PLUGINFILE@@/' . $nameonly, $summary);
             }
         }
     }
-
     return $summary;
 }
 /**
@@ -1078,6 +1061,7 @@ function local_rollover_wizard_update_internal_links($rolloverqueue, $enabled) {
         if (!in_array($sourcesection->section, $includedsections) && $rolloverqueue->rollovermode == 'previouscourse') {
             continue;
         }
+
         if (!$enabled) {
             $targetsection->summary = local_rollover_wizard_rewrite_summary($sourcesection, $targetsection);
             $targetsection->summaryformat = $sourcesection->summaryformat;
@@ -1160,6 +1144,16 @@ function get_activities_by_section($sectionid) {
     return $contents;
 }
 
+/**
+ * Count total number of questions in the question bank for a given course.
+ *
+ * This function checks the number of questions available in the question bank
+ * of the specified course. It is useful for diagnostics or validating course
+ * integrity before performing operations like rollover.
+ *
+ * @param stdClass $course The course object.
+ * @return int The total number of questions in the question bank for the course.
+ */
 function local_rollover_wizard_check_total_question_bank_course($course) {
     global $DB;
     $sql = "
@@ -1190,4 +1184,54 @@ function local_rollover_wizard_check_total_question_bank_course($course) {
         $totalquestion = array_sum(array_column($questions, 'questioncount'));
     }
     return [$totalquestion, $questions];
+}
+
+/**
+ * Replaces pluginfile.php URLs with @@PLUGINFILE@@ in course section summaries.
+ *
+ * This function searches all course_sections with summaries containing
+ * 'pluginfile.php' and replaces them with Moodle's @@PLUGINFILE@@ placeholder.
+ * It respects a configurable limit set in the plugin settings.
+ *
+ * @return void
+ */
+function local_rollover_wizard_replace_urls_section() {
+    global $CFG, $DB;
+    require_once($CFG->dirroot . '/local/rollover_wizard/lib.php');
+    $limit = (int) get_config("local_rollover_wizard", "replace_url_limit");
+    $sql = "
+    SELECT cs.id, cs.summary, cs.course, c.fullname
+        FROM {course_sections} cs
+        JOIN {course} c ON c.id = cs.course
+        WHERE cs.summary LIKE :summary";
+    $params = ['summary' => '%pluginfile.php%'];
+    if ($limit > 0) {
+        $sql .= " LIMIT " . $limit;
+    }
+    $sections = $DB->get_records_sql($sql, $params);
+    if (!empty($sections)) {
+        foreach ($sections as $section) {
+            $summary = $section->summary;
+            $original = $summary;
+            $pattern = '/(src|href)="([^"]*pluginfile\.php[^"]*\/([^\/"]+))"/i';
+            $summary = preg_replace_callback($pattern, function ($matches) {
+                $filename = urldecode($matches[3]);
+                return $matches[1] . '="@@PLUGINFILE@@/' . $filename . '"';
+            }, $summary);
+            if ($summary !== $original) {
+                $DB->update_record('course_sections', (object)[
+                    'id' => $section->id,
+                    'summary' => $summary,
+                ]);
+                $log = new stdClass();
+                $log->sectionid = $section->id;
+                $log->courseid = $section->course;
+                $log->oldsummary = $original;
+                $log->newsummary = $summary;
+                $log->timecreated = time();
+                $DB->insert_record('local_rollover_wizard_sectionlog', $log);
+                mtrace("Updated section ID {$section->id} in course: {$section->fullname}");
+            }
+        }
+    }
 }

--- a/settings.php
+++ b/settings.php
@@ -99,13 +99,25 @@ if ($hassiteconfig) {
                 20000 => "20000",
             ];
     $element = new admin_setting_configselect('local_rollover_wizard/cron_limit_question',
-     get_string("setting_page:limit_question", "local_rollover_wizard"),
+    get_string("setting_page:limit_question", "local_rollover_wizard"),
                                 "",
         500, $limit);
     $settings->add($element);
-
-
     $element = new admin_setting_configtextarea('local_rollover_wizard/activities_notberolled', 'Activities not to be rolled over',
                                 'Put in activity types separated by commas. Ex: turnitin,forum', null, PARAM_TEXT, '20', '8');
+    $settings->add($element);
+
+    $element = new admin_setting_configselect(
+    'local_rollover_wizard/replace_url_limit',
+    'Replace URL limit per run',
+    'Select how many course sections should be processed per execution when replacing pluginfile URLs in course sections.',
+    10,
+    [
+        10 => '10 sections per run',
+        25 => '25 sections per run',
+        50 => '50 sections per run',
+        -1 => 'All sections (no limit)',
+    ]
+    );
     $settings->add($element);
 }

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_rollover_wizard';
-$plugin->release = '1.0';
-$plugin->version = 2025070200;
+$plugin->release  = '1.0';
+$plugin->version  = 2025072901;
 $plugin->requires = 2021051700;
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
This PR adds a scheduled task to replace the old hardcoded course section links.
It also includes logging to track which sections are affected by the task, with the results stored in the `local_rollover_wizard_sectionlog` database table.